### PR TITLE
fix(codegen): wire exitSuccess/exitFailure in the direct dispatcher

### DIFF
--- a/crates/bhc-codegen/src/llvm/lower.rs
+++ b/crates/bhc-codegen/src/llvm/lower.rs
@@ -46330,6 +46330,34 @@ impl<'ctx, 'm> Lowering<'ctx, 'm> {
                 Ok(Some(self.int_to_ptr(extended)?.into()))
             }
 
+            // System.Exit — these are arity-0/1 IO actions that reach this
+            // direct dispatcher when used as bare values (e.g. `main = exitFailure`),
+            // so they must be handled here as well as in `lower_builtin`. Without
+            // these arms they fall through to the generic "stub: <name> not
+            // implemented" runtime panic.
+            "exitSuccess" => self.lower_builtin_exit_success(),
+            "exitFailure" => self.lower_builtin_exit_failure(),
+            "exitWith" => {
+                // args are already lowered here (unlike lower_builtin's Expr path).
+                let int_val = self.coerce_to_int(args[0])?;
+                let code_i32 = self
+                    .builder()
+                    .build_int_truncate(int_val, self.type_mapper().i32_type(), "exit_code")
+                    .map_err(|e| {
+                        CodegenError::Internal(format!("exitWith: truncate failed: {:?}", e))
+                    })?;
+                let rts_fn = self.functions.get(&VarId::new(1000065)).ok_or_else(|| {
+                    CodegenError::Internal("bhc_exit not declared".to_string())
+                })?;
+                self.builder()
+                    .build_call(*rts_fn, &[code_i32.into()], "")
+                    .map_err(|e| CodegenError::Internal(format!("exitWith failed: {:?}", e)))?;
+                self.builder()
+                    .build_unreachable()
+                    .map_err(|e| CodegenError::Internal(format!("unreachable failed: {:?}", e)))?;
+                Ok(Some(self.type_mapper().ptr_type().const_null().into()))
+            }
+
             // Async exception masking
             "getMaskingState" => self.lower_builtin_get_masking_state(),
             "mask_" => {


### PR DESCRIPTION
`exitSuccess` and `exitFailure` are arity-0 IO actions. When used as bare
values (e.g. `main = exitFailure`) they are lowered through
`lower_builtin_direct` (the arity-0 / bare-value path), not the
application-based `lower_builtin`. That dispatcher had no arms for them, so
they fell through to the generic `stub: <name> not implemented` runtime panic
(abort, status 134). A program could therefore neither exit successfully nor
signal failure.

## Fix

Add the `System.Exit` arms to `lower_builtin_direct`, reusing the existing
`bhc_exit_success` / `bhc_exit_failure` / `bhc_exit` RTS entry points. `exitWith`
is inlined here because arguments are already lowered values on this path.

## Verification (compiled binaries)

```
main = exitSuccess   -> exit 0
main = exitFailure   -> exit 1
```

Previously both aborted with status 134. This makes `hx test --backend bhc
--native` pass/fail signaling reliable.

## Out of scope (separate, deeper bugs — noted, not fixed here)

- `exitWith (ExitFailure n)` still needs the `ExitCode` data constructors, which
  are currently stubbed (`stub: ExitFailure not implemented`).
- `main = error _` exits **0** because the main runner does not force the
  bottoming action — an evaluation/runner issue independent of exit wiring.