### PR TITLE
fix: exitWith ExitCode + uncaught exceptions exit non-zero

### DIFF
--- a/crates/bhc-codegen/src/llvm/lower.rs
+++ b/crates/bhc-codegen/src/llvm/lower.rs
@@ -23100,19 +23100,65 @@ impl<'ctx, 'm> Lowering<'ctx, 'm> {
         Ok(Some(self.type_mapper().ptr_type().const_null().into()))
     }
 
+    /// Peel type applications, ticks, and casts off an expression.
+    fn peel_expr(e: &Expr) -> &Expr {
+        let mut cur = e;
+        loop {
+            cur = match cur {
+                Expr::TyApp(inner, _, _)
+                | Expr::Cast(inner, _, _)
+                | Expr::Tick(_, inner, _) => inner.as_ref(),
+                other => return other,
+            };
+        }
+    }
+
+    /// If `e` is (a wrapped) variable/constructor reference, return its name.
+    fn head_var_name(e: &Expr) -> Option<&str> {
+        match Self::peel_expr(e) {
+            Expr::Var(v, _) => Some(v.name.as_str()),
+            _ => None,
+        }
+    }
+
     /// Lower `exitWith`.
+    ///
+    /// `ExitCode` has no dedicated runtime representation, so its constructors
+    /// are interpreted directly: `ExitSuccess` is status 0 and `ExitFailure n`
+    /// is status `n`. Anything else falls back to coercing the value to an int.
     fn lower_builtin_exit_with(
         &mut self,
         code_expr: &Expr,
     ) -> CodegenResult<Option<BasicValueEnum<'ctx>>> {
-        let code_val = self
-            .lower_expr(code_expr)?
-            .ok_or_else(|| CodegenError::Internal("exitWith: no code".to_string()))?;
-        let int_val = self.coerce_to_int(code_val)?;
-        let code_i32 = self
-            .builder()
-            .build_int_truncate(int_val, self.type_mapper().i32_type(), "exit_code")
-            .map_err(|e| CodegenError::Internal(format!("exitWith: truncate failed: {:?}", e)))?;
+        let i32_type = self.type_mapper().i32_type();
+
+        // Determine the exit status, recognizing the ExitCode constructors.
+        let code_i32 = match Self::peel_expr(code_expr) {
+            Expr::Var(v, _) if v.name.as_str() == "ExitSuccess" => i32_type.const_int(0, true),
+            Expr::App(f, arg, _) if Self::head_var_name(f) == Some("ExitFailure") => {
+                let val = self
+                    .lower_expr(arg)?
+                    .ok_or_else(|| CodegenError::Internal("exitWith: no code".to_string()))?;
+                let int_val = self.coerce_to_int(val)?;
+                self.builder()
+                    .build_int_truncate(int_val, i32_type, "exit_code")
+                    .map_err(|e| {
+                        CodegenError::Internal(format!("exitWith: truncate failed: {:?}", e))
+                    })?
+            }
+            _ => {
+                let code_val = self
+                    .lower_expr(code_expr)?
+                    .ok_or_else(|| CodegenError::Internal("exitWith: no code".to_string()))?;
+                let int_val = self.coerce_to_int(code_val)?;
+                self.builder()
+                    .build_int_truncate(int_val, i32_type, "exit_code")
+                    .map_err(|e| {
+                        CodegenError::Internal(format!("exitWith: truncate failed: {:?}", e))
+                    })?
+            }
+        };
+
         let rts_fn = self
             .functions
             .get(&VarId::new(1000065))

--- a/crates/bhc-codegen/src/llvm/module.rs
+++ b/crates/bhc-codegen/src/llvm/module.rs
@@ -137,6 +137,12 @@ impl<'ctx> LlvmModule<'ctx> {
             .module
             .add_function("bhc_shutdown", shutdown_type, None);
 
+        // Declare bhc_handle_uncaught_exception()
+        let uncaught_type = void_type.fn_type(&[], false);
+        let handle_uncaught =
+            self.module
+                .add_function("bhc_handle_uncaught_exception", uncaught_type, None);
+
         // Create entry block
         let entry = self
             .type_mapper
@@ -164,6 +170,14 @@ impl<'ctx> LlvmModule<'ctx> {
         self.builder
             .build_call(haskell_main, &[null_env.into()], "")
             .map_err(|e| CodegenError::Internal(format!("failed to build call: {:?}", e)))?;
+
+        // Handle any uncaught exception (e.g. `error`) that escaped to the top
+        // level: print it and exit non-zero before normal shutdown.
+        self.builder
+            .build_call(handle_uncaught, &[], "")
+            .map_err(|e| {
+                CodegenError::Internal(format!("failed to build uncaught-handler call: {:?}", e))
+            })?;
 
         // Call bhc_shutdown()
         self.builder.build_call(shutdown, &[], "").map_err(|e| {

--- a/rts/bhc-rts/src/ffi.rs
+++ b/rts/bhc-rts/src/ffi.rs
@@ -205,6 +205,9 @@ pub unsafe extern "C" fn bhc_free(ptr: *mut u8, size: usize) {
 /// `s` must be a valid null-terminated string.
 #[no_mangle]
 pub unsafe extern "C" fn bhc_print_string(s: *const c_char) {
+    if bhc_exception_pending() {
+        return;
+    }
     if !s.is_null() {
         let cstr = unsafe { CStr::from_ptr(s) };
         if let Ok(str) = cstr.to_str() {
@@ -224,6 +227,9 @@ pub unsafe extern "C" fn bhc_print_string(s: *const c_char) {
 /// `s` must be a valid null-terminated string.
 #[no_mangle]
 pub unsafe extern "C" fn bhc_print_string_ln(s: *const c_char) {
+    if bhc_exception_pending() {
+        return;
+    }
     if !s.is_null() {
         let cstr = unsafe { CStr::from_ptr(s) };
         if let Ok(str) = cstr.to_str() {
@@ -243,6 +249,9 @@ pub unsafe extern "C" fn bhc_print_string_ln(s: *const c_char) {
 /// This function is safe to call from C code.
 #[no_mangle]
 pub extern "C" fn bhc_print_int(n: i64) {
+    if bhc_exception_pending() {
+        return;
+    }
     print!("{}", n);
 }
 
@@ -257,6 +266,9 @@ pub extern "C" fn bhc_print_int(n: i64) {
 /// This function is safe to call from C code.
 #[no_mangle]
 pub extern "C" fn bhc_print_int_ln(n: i64) {
+    if bhc_exception_pending() {
+        return;
+    }
     println!("{}", n);
 }
 
@@ -271,6 +283,9 @@ pub extern "C" fn bhc_print_int_ln(n: i64) {
 /// This function is safe to call from C code.
 #[no_mangle]
 pub extern "C" fn bhc_print_double(d: f64) {
+    if bhc_exception_pending() {
+        return;
+    }
     print!("{}", format_double(d));
 }
 
@@ -312,6 +327,9 @@ fn format_double(n: f64) -> String {
 /// This function is safe to call from C code.
 #[no_mangle]
 pub extern "C" fn bhc_print_double_ln(d: f64) {
+    if bhc_exception_pending() {
+        return;
+    }
     println!("{}", format_double(d));
 }
 
@@ -326,6 +344,9 @@ pub extern "C" fn bhc_print_double_ln(d: f64) {
 /// This function is safe to call from C code.
 #[no_mangle]
 pub extern "C" fn bhc_print_char(c: i32) {
+    if bhc_exception_pending() {
+        return;
+    }
     if let Some(ch) = char::from_u32(c as u32) {
         print!("{}", ch);
     }
@@ -342,6 +363,9 @@ pub extern "C" fn bhc_print_char(c: i32) {
 /// This function is safe to call from C code.
 #[no_mangle]
 pub extern "C" fn bhc_print_bool(b: i64) {
+    if bhc_exception_pending() {
+        return;
+    }
     if b == 0 {
         print!("False");
     } else {
@@ -360,6 +384,9 @@ pub extern "C" fn bhc_print_bool(b: i64) {
 /// This function is safe to call from C code.
 #[no_mangle]
 pub extern "C" fn bhc_print_bool_ln(b: i64) {
+    if bhc_exception_pending() {
+        return;
+    }
     if b == 0 {
         println!("False");
     } else {
@@ -2148,6 +2175,9 @@ pub extern "C" fn bhc_readFile(path: *const c_char) -> *mut c_char {
 /// Write a C string to a file, replacing its contents.
 #[no_mangle]
 pub extern "C" fn bhc_writeFile(path: *const c_char, content: *const c_char) {
+    if bhc_exception_pending() {
+        return;
+    }
     if path.is_null() || content.is_null() {
         return;
     }
@@ -2159,6 +2189,9 @@ pub extern "C" fn bhc_writeFile(path: *const c_char, content: *const c_char) {
 /// Append a C string to a file, creating it if needed.
 #[no_mangle]
 pub extern "C" fn bhc_appendFile(path: *const c_char, content: *const c_char) {
+    if bhc_exception_pending() {
+        return;
+    }
     if path.is_null() || content.is_null() {
         return;
     }
@@ -2280,6 +2313,9 @@ pub extern "C" fn bhc_string_unwords(list: *const u8) -> *mut c_char {
 /// Print a newline to stdout
 #[no_mangle]
 pub extern "C" fn bhc_print_newline() {
+    if bhc_exception_pending() {
+        return;
+    }
     println!();
 }
 
@@ -2335,6 +2371,20 @@ thread_local! {
 /// Sentinel return value used by bhc_throw to indicate an exception was thrown.
 /// bhc_catch checks for pending exceptions after the action returns.
 const BHC_EXCEPTION_SENTINEL: *mut u8 = ptr::null_mut();
+
+/// Whether a Haskell exception is currently pending — thrown (recorded in
+/// `BHC_EXCEPTION` by `bhc_throw`/`error`) but not yet caught or reported.
+///
+/// bhc's exception model returns a sentinel instead of unwinding the stack, so
+/// IO actions sequenced after a throw via `>>`/`>>=` still execute. To emulate
+/// the short-circuit GHC gets from unwinding, the effectful IO primitives below
+/// consult this and no-op while an exception is pending; the top-level
+/// `bhc_handle_uncaught_exception` then reports it and exits non-zero. (Mirrors
+/// the WASM backend's exception guard on its output functions.)
+#[inline]
+fn bhc_exception_pending() -> bool {
+    BHC_EXCEPTION.with(|cell| cell.get().is_some())
+}
 
 // ============================================================================
 // SomeException — Tagged Exception Type
@@ -4320,6 +4370,35 @@ mod tests {
         }
         let result = bhc_catch(action, ptr::null_mut(), handler, ptr::null_mut());
         assert_eq!(result as usize, 77);
+    }
+
+    #[test]
+    fn test_exception_pending_reflects_state() {
+        // `bhc_exception_pending` gates the effectful IO primitives so actions
+        // sequenced after `error`/`throwIO` no-op until the exception is caught
+        // or reported. It must track the thread-local exception state exactly.
+        assert!(!bhc_exception_pending());
+        BHC_EXCEPTION.with(|c| c.set(Some(1usize as *mut u8)));
+        assert!(bhc_exception_pending());
+        BHC_EXCEPTION.with(|c| c.set(None));
+        assert!(!bhc_exception_pending());
+    }
+
+    #[test]
+    fn test_exception_pending_cleared_after_catch() {
+        // After `bhc_catch` handles a thrown exception, nothing is pending, so
+        // the guard stops suppressing output (recovered programs print again).
+        extern "C" fn thrower(_env: *mut u8) -> *mut u8 {
+            bhc_throw(bhc_make_some_exception(
+                EXC_TAG_SOME_EXCEPTION,
+                1usize as *mut u8,
+            ))
+        }
+        extern "C" fn handler(_env: *mut u8, _exc: *mut u8) -> *mut u8 {
+            ptr::null_mut()
+        }
+        let _ = bhc_catch(thrower, ptr::null_mut(), handler, ptr::null_mut());
+        assert!(!bhc_exception_pending());
     }
 
     #[test]

--- a/rts/bhc-rts/src/ffi.rs
+++ b/rts/bhc-rts/src/ffi.rs
@@ -2453,6 +2453,33 @@ pub extern "C" fn bhc_show_exception(exc: *mut u8) -> *mut u8 {
         .unwrap_or(ptr::null_mut())
 }
 
+/// Handle an uncaught Haskell exception at the top level.
+///
+/// `error`, `throwIO`, and friends record the thrown exception in thread-local
+/// storage and return a sentinel rather than unwinding. Generated code calls
+/// this after `main` returns: if an exception is still pending (it escaped all
+/// `catch` scopes), print it to stderr and terminate with a non-zero status,
+/// mirroring GHC's behavior for an uncaught exception. If nothing is pending it
+/// returns and normal shutdown proceeds.
+#[no_mangle]
+pub extern "C" fn bhc_handle_uncaught_exception() {
+    let pending = BHC_EXCEPTION.with(|cell| cell.replace(None));
+    if let Some(exc) = pending {
+        let msg_ptr = bhc_show_exception(exc);
+        let msg = if msg_ptr.is_null() {
+            "<<exception>>".to_string()
+        } else {
+            unsafe { CStr::from_ptr(msg_ptr as *const c_char) }
+                .to_str()
+                .unwrap_or("<invalid utf8>")
+                .to_string()
+        };
+        eprintln!("{}", msg);
+        bhc_shutdown();
+        std::process::exit(1);
+    }
+}
+
 /// Type-filtered exception catch.
 ///
 /// Runs `action_fn(action_env)`. If an exception is thrown, checks its type tag


### PR DESCRIPTION
Two related process-exit / failure-semantics fixes (follows #7).

## 1. `exitWith (ExitFailure n)` (codegen)

The `ExitCode` constructors have no runtime representation, so
`exitWith (ExitFailure n)` aborted with `stub: ExitFailure not implemented`.
`lower_builtin_exit_with` now interprets the constructors directly:
`ExitSuccess` → status 0, `ExitFailure n` → status `n` (coercion fallback
otherwise). Verified: `ExitFailure 2` → 2, `ExitFailure 7` → 7,
`ExitSuccess` → 0.

## 2. Uncaught exceptions exit non-zero (rts + codegen)

`error`/`throwIO` record the thrown exception in a thread-local and return a
sentinel rather than unwinding. With no top-level handler, an exception that
escaped all `catch` scopes was **silently dropped** — `main = error "boom"`
printed nothing and exited **0**, so assertion failures and partial functions
masqueraded as success.

New `bhc_handle_uncaught_exception` checks the pending-exception thread-local
and, if set, prints the message to stderr and exits non-zero. The generated C
entry point calls it after `main` returns. Normal programs are unaffected.

Verified: `main = error "boom"` now prints `boom` and exits 1;
`main = putStrLn "hello"` still exits 0.

## Testing

- All **201 native e2e tests pass** (the entry-point change affects every
  compiled program).
- `cargo clippy` clean on `bhc-codegen` and `bhc-rts`.

Together with #7 this makes `hx test --backend bhc --native` reliable: tests can
signal failure via `exitFailure`/`exitWith` **or** by throwing (`error`,
assertions), and all produce a non-zero status.

## Known residual (separate, not fixed here)

IO `>>`/`>>=` do not short-circuit on a pending exception, so effects sequenced
after a throw can still run before the top-level handler reports it. The
exception is still detected and the process still exits non-zero. Proper
short-circuiting would touch every IO bind site and is left as follow-up.