### PR TITLE
chore: green CI — cargo fmt, clippy lints, and a broken doc link

### DIFF
--- a/crates/bhc-codegen/src/llvm/lower.rs
+++ b/crates/bhc-codegen/src/llvm/lower.rs
@@ -23105,9 +23105,9 @@ impl<'ctx, 'm> Lowering<'ctx, 'm> {
         let mut cur = e;
         loop {
             cur = match cur {
-                Expr::TyApp(inner, _, _)
-                | Expr::Cast(inner, _, _)
-                | Expr::Tick(_, inner, _) => inner.as_ref(),
+                Expr::TyApp(inner, _, _) | Expr::Cast(inner, _, _) | Expr::Tick(_, inner, _) => {
+                    inner.as_ref()
+                }
                 other => return other,
             };
         }
@@ -46392,9 +46392,10 @@ impl<'ctx, 'm> Lowering<'ctx, 'm> {
                     .map_err(|e| {
                         CodegenError::Internal(format!("exitWith: truncate failed: {:?}", e))
                     })?;
-                let rts_fn = self.functions.get(&VarId::new(1000065)).ok_or_else(|| {
-                    CodegenError::Internal("bhc_exit not declared".to_string())
-                })?;
+                let rts_fn = self
+                    .functions
+                    .get(&VarId::new(1000065))
+                    .ok_or_else(|| CodegenError::Internal("bhc_exit not declared".to_string()))?;
                 self.builder()
                     .build_call(*rts_fn, &[code_i32.into()], "")
                     .map_err(|e| CodegenError::Internal(format!("exitWith failed: {:?}", e)))?;

--- a/crates/bhc-driver/src/lib.rs
+++ b/crates/bhc-driver/src/lib.rs
@@ -2309,8 +2309,7 @@ impl Compiler {
         }
 
         // Transitive closure of the requested ids over `depends:`.
-        let by_id: FxHashMap<&str, &ConfPackage> =
-            all.iter().map(|p| (p.id.as_str(), p)).collect();
+        let by_id: FxHashMap<&str, &ConfPackage> = all.iter().map(|p| (p.id.as_str(), p)).collect();
         let mut visible: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
         let mut stack: Vec<String> = visible_ids.clone();
         while let Some(id) = stack.pop() {

--- a/crates/bhc-driver/src/lib.rs
+++ b/crates/bhc-driver/src/lib.rs
@@ -4072,8 +4072,8 @@ impl Compiler {
         self.check_files_ordered_reporting(paths, None)
     }
 
-    /// Like [`check_files_ordered`], but only reports results for the modules
-    /// whose source path is in `report_only`.
+    /// Like [`Self::check_files_ordered`], but only reports results for the
+    /// modules whose source path is in `report_only`.
     ///
     /// All files in `paths` are still parsed, ordered, and type-checked so that
     /// their exports are registered for downstream import resolution. When
@@ -4084,7 +4084,7 @@ impl Compiler {
     /// without polluting its reported check results.
     ///
     /// When `report_only` is `None`, every module is reported (the original
-    /// [`check_files_ordered`] behavior).
+    /// [`Self::check_files_ordered`] behavior).
     pub fn check_files_ordered_reporting(
         &self,
         paths: &[Utf8PathBuf],

--- a/crates/bhc-driver/tests/integration.rs
+++ b/crates/bhc-driver/tests/integration.rs
@@ -1382,7 +1382,9 @@ main = mapM_ putStrLn (shout "a,b,c")
     let dep = Utf8PathBuf::from(dep_dir.path().to_str().unwrap());
 
     // Without the dependency: both target modules are skipped (cascade).
-    let bare = compiler.check_with_discovery(&[app.clone()]).unwrap();
+    let bare = compiler
+        .check_with_discovery(std::slice::from_ref(&app))
+        .unwrap();
     let bare_skipped = bare
         .iter()
         .filter(|(_, r)| {
@@ -1468,10 +1470,7 @@ main = mapM_ putStrLn (splitOnComma "a,b,c")
     .unwrap();
 
     // Without the DB the import is unresolved; with it, the check succeeds.
-    let consumer = CompilerBuilder::new()
-        .package_db(db_path)
-        .build()
-        .unwrap();
+    let consumer = CompilerBuilder::new().package_db(db_path).build().unwrap();
     let main_path = Utf8PathBuf::from(main_hs.to_str().unwrap());
     let result = consumer.check_file(&main_path);
     assert!(
@@ -1522,7 +1521,7 @@ splitOnComma s = case break (== ',') s of
         .build()
         .unwrap();
     producer
-        .compile_module_only(&Utf8PathBuf::from(
+        .compile_module_only(Utf8PathBuf::from(
             data_dir.join("Split.hs").to_str().unwrap(),
         ))
         .unwrap();
@@ -1556,7 +1555,7 @@ main = mapM_ putStrLn (splitOnComma "a,b,c")
         .package_db(Utf8PathBuf::from(pkgdb.path().to_str().unwrap()))
         .build()
         .unwrap();
-    let result = consumer.check_file(&Utf8PathBuf::from(main_hs.to_str().unwrap()));
+    let result = consumer.check_file(Utf8PathBuf::from(main_hs.to_str().unwrap()));
     assert!(
         result.is_ok(),
         "consumer should resolve import via .conf import-dirs: {:?}",
@@ -1600,7 +1599,7 @@ fn test_package_db_scoping_and_exposed_modules() {
         .unwrap();
     for m in ["Public", "Hidden"] {
         producer
-            .compile_module_only(&Utf8PathBuf::from(
+            .compile_module_only(Utf8PathBuf::from(
                 data_dir.join(format!("{m}.hs")).to_str().unwrap(),
             ))
             .unwrap();
@@ -1645,28 +1644,28 @@ fn test_package_db_scoping_and_exposed_modules() {
     // Exposed module resolves.
     assert!(
         checker(&[])
-            .check_file(&write_main("Data.Public", "pub"))
+            .check_file(write_main("Data.Public", "pub"))
             .is_ok(),
         "exposed module should resolve"
     );
     // Non-exposed module does NOT resolve even though its .bhi exists.
     assert!(
         checker(&[])
-            .check_file(&write_main("Data.Hidden", "hidden"))
+            .check_file(write_main("Data.Hidden", "hidden"))
             .is_err(),
         "non-exposed module must not resolve"
     );
     // Matching --package-id keeps it visible.
     assert!(
         checker(&["mypkg-1.0.0-abc123"])
-            .check_file(&write_main("Data.Public", "pub"))
+            .check_file(write_main("Data.Public", "pub"))
             .is_ok(),
         "exposed module should resolve when its package id is selected"
     );
     // A non-matching --package-id hides the package entirely.
     assert!(
         checker(&["other-9.9-zzz"])
-            .check_file(&write_main("Data.Public", "pub"))
+            .check_file(write_main("Data.Public", "pub"))
             .is_err(),
         "package must be hidden when only an unrelated package id is selected"
     );
@@ -1709,7 +1708,7 @@ fn test_package_db_depends_transitive_visibility() {
             .hidir(hidir.clone())
             .build()
             .unwrap()
-            .compile_module_only(&Utf8PathBuf::from(
+            .compile_module_only(Utf8PathBuf::from(
                 data.join(format!("{module}.hs")).to_str().unwrap(),
             ))
             .unwrap();
@@ -1752,20 +1751,20 @@ fn test_package_db_depends_transitive_visibility() {
     // Selecting P exposes P, and Q transitively via depends.
     assert!(
         checker("p-1.0-aaa")
-            .check_file(&write_main("Data.P", "valP"))
+            .check_file(write_main("Data.P", "valP"))
             .is_ok(),
         "selected package P should resolve"
     );
     assert!(
         checker("p-1.0-aaa")
-            .check_file(&write_main("Data.Q", "valQ"))
+            .check_file(write_main("Data.Q", "valQ"))
             .is_ok(),
         "P's transitive dependency Q should resolve"
     );
     // Selecting only Q must not expose P (no reverse edge).
     assert!(
         checker("q-1.0-bbb")
-            .check_file(&write_main("Data.P", "valP"))
+            .check_file(write_main("Data.P", "valP"))
             .is_err(),
         "selecting only Q must not expose its dependent P"
     );

--- a/crates/bhc-wasm/src/core_lower.rs
+++ b/crates/bhc-wasm/src/core_lower.rs
@@ -8609,13 +8609,7 @@ fn build_list_fn(name: &str, id: &mut usize) -> Option<(Var, Expr)> {
                         vec![],
                         papp2(pref("find", id), pev(&p), pev(&ys)),
                     ),
-                    palt(
-                        "True",
-                        1,
-                        0,
-                        vec![],
-                        papp(pref("Just", id), pev(&y)),
-                    ),
+                    palt("True", 1, 0, vec![], papp(pref("Just", id), pev(&y))),
                 ],
             );
             plam(

--- a/crates/bhc/src/main.rs
+++ b/crates/bhc/src/main.rs
@@ -414,7 +414,9 @@ fn compile_files(files: &[PathBuf], cli: &Cli) -> Result<()> {
         compiler.compile_files_ordered(utf8_paths.iter().map(|p| p.as_path()))
     } else if utf8_paths.len() == 1 {
         if cli.compile_only {
-            compiler.compile_module_only(utf8_paths[0].as_path()).map(|o| vec![o])
+            compiler
+                .compile_module_only(utf8_paths[0].as_path())
+                .map(|o| vec![o])
         } else {
             compiler.compile_with_discovery(utf8_paths[0].as_path())
         }


### PR DESCRIPTION
The CI **Check** and **Documentation** jobs have been red on `main` since the package-deps PRs landed (green at `6c158be`, red from `6d00486` on) — accumulated un-formatted / un-linted / un-doc-linkable code across several merges, not any single feature.

## Changes (no functional change)
- **fmt** — `cargo fmt --all` over `bhc/src/main.rs`, `bhc-driver/src/lib.rs`, `bhc-driver/tests/integration.rs`, `bhc-codegen/src/llvm/lower.rs`, `bhc-wasm/src/core_lower.rs`.
- **clippy** (`-D warnings`) — 12 lints in `bhc-driver/tests/integration.rs` (`needless_borrow`, one `cloned_ref_to_slice_refs` → `std::slice::from_ref`).
- **docs** — fix the broken intra-doc link `check_files_ordered` → `Self::check_files_ordered` (was failing the Documentation job under `-D rustdoc::broken-intra-doc-links`).

## Verification (CI-equivalent, locally)
- `cargo fmt --all -- --check` → clean
- `cargo clippy --all-targets -- -D warnings` → no warnings
- `cargo doc --no-deps -p bhc-driver` with `-D warnings` → clean