### PR TITLE
fix(codegen): findIndex segfault on a Bool predicate result

### DIFF
--- a/crates/bhc-codegen/src/llvm/lower.rs
+++ b/crates/bhc-codegen/src/llvm/lower.rs
@@ -28495,16 +28495,18 @@ impl<'ctx, 'm> Lowering<'ctx, 'm> {
             .basic()
             .ok_or_else(|| CodegenError::Internal("findIndex: pred returned void".to_string()))?;
 
-        // Check Bool result tag
-        let result_tag = match pred_result {
-            BasicValueEnum::PointerValue(p) => self.extract_adt_tag(p)?,
-            BasicValueEnum::IntValue(i) => i,
-            _ => {
-                return Err(CodegenError::TypeError(
-                    "findIndex: pred should return Bool".to_string(),
-                ))
-            }
-        };
+        // The predicate returns a Bool, which may be a tagged-int-as-pointer
+        // (0/1, e.g. from `>`/`==`) rather than a heap ADT — extract_adt_tag
+        // would dereference it and segfault. Use extract_bool_tag, which
+        // discriminates the two (as `find`/`filter`/`all`/`any` do).
+        let result_tag = self.extract_bool_tag(pred_result.into_pointer_value())?;
+        // extract_bool_tag may split the current block, so the loop back-edge
+        // branches from this block, not the original loop_body — capture it for
+        // the PHI predecessors below.
+        let body_end_block = self
+            .builder()
+            .get_insert_block()
+            .ok_or_else(|| CodegenError::Internal("findIndex: no current block".to_string()))?;
         let is_true = self
             .builder()
             .build_int_compare(
@@ -28526,10 +28528,10 @@ impl<'ctx, 'm> Lowering<'ctx, 'm> {
             .build_conditional_branch(is_true, found_block, loop_header)
             .map_err(|e| CodegenError::Internal(format!("findIndex: branch: {:?}", e)))?;
 
-        list_phi.add_incoming(&[(&list_ptr, entry_block), (&tail, loop_body)]);
+        list_phi.add_incoming(&[(&list_ptr, entry_block), (&tail, body_end_block)]);
         counter_phi.add_incoming(&[
             (&i64_type.const_zero(), entry_block),
-            (&next_counter, loop_body),
+            (&next_counter, body_end_block),
         ]);
 
         // Found: return Just counter

--- a/crates/bhc-e2e-tests/fixtures/tier2_functions/maybe_returning_fns/expected.txt
+++ b/crates/bhc-e2e-tests/fixtures/tier2_functions/maybe_returning_fns/expected.txt
@@ -2,5 +2,7 @@ Just 4
 Nothing
 Just 2
 Nothing
+Just 2
+Nothing
 Just 20
 Nothing

--- a/crates/bhc-e2e-tests/fixtures/tier2_functions/maybe_returning_fns/main.hs
+++ b/crates/bhc-e2e-tests/fixtures/tier2_functions/maybe_returning_fns/main.hs
@@ -2,7 +2,7 @@
 -- rendering a raw pointer on both backends (the runtime Maybe-show path was
 -- only wired for readMaybe / partially-applied calls). The Just field is shown
 -- as Int, the common case.
-import Data.List (find, elemIndex)
+import Data.List (find, elemIndex, findIndex)
 
 main :: IO ()
 main = do
@@ -10,5 +10,7 @@ main = do
     print (find (> 10) [1, 2, 3 :: Int])
     print (elemIndex 3 [1, 2, 3, 4 :: Int])
     print (elemIndex 9 [1, 2, 3 :: Int])
+    print (findIndex (> 2) [1, 2, 3, 4 :: Int])
+    print (findIndex (> 9) [1, 2, 3 :: Int])
     print (lookup 2 [(1, 10), (2, 20), (3, 30) :: (Int, Int)])
     print (lookup 5 [(1, 10), (2, 20) :: (Int, Int)])


### PR DESCRIPTION
Native `findIndex p xs` segfaulted (exit 139) for any predicate returning a Bool via a comparison (`findIndex (>2)`, `findIndex even`, …): the loop called `extract_adt_tag` on the predicate's result, but a Bool from `>`/`==` is a tagged-int-as-pointer (0/1), so dereferencing it as a heap ADT crashed. Same bug class as the earlier all/any and field-`==` segfaults.

## Fix
- Use `extract_bool_tag` (discriminates tagged-int from heap ADT, as `find`/`filter`/`all`/`any` do).
- `extract_bool_tag` splits the current block, so the loop PHIs now use the actual post-split block as the back-edge predecessor (not the original `loop_body`).

`elemIndex` was already correct (compares values, no predicate). WASM `findIndex` already worked.

## Verification
- Extended `maybe_returning_fns` fixture with `findIndex` — native == wasm (`Just 2`/`Nothing`).
- All **201 native e2e tests pass**; clippy clean.